### PR TITLE
Edits to make rpcserver, rpcclient compile with Boost-1.66

### DIFF
--- a/contrib/gitian-descriptors/boost-win32.yml
+++ b/contrib/gitian-descriptors/boost-win32.yml
@@ -34,5 +34,5 @@ script: |
   cd $TMPDIR
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
-  zip -r boost-win32-1.47.0-gitian.zip *
-  cp boost-win32-1.47.0-gitian.zip $OUTDIR
+  zip -r boost-win32-1.66.0-gitian.zip *
+  cp boost-win32-1.66.0-gitian.zip $OUTDIR

--- a/contrib/gitian-descriptors/gitian-win32.yml
+++ b/contrib/gitian-descriptors/gitian-win32.yml
@@ -16,7 +16,7 @@ remotes:
   "dir": "okcash"
 files:
 - "qt-win32-4.7.4-gitian.zip"
-- "boost-win32-1.47.0-gitian.zip"
+- "boost-win32-1.66.0-gitian.zip"
 - "okcash-deps-0.0.1.zip"
 script: |
   #
@@ -26,10 +26,10 @@ script: |
   cd $HOME/build/
   export PATH=$PATH:$HOME/qt/bin/
   #
-  mkdir boost_1_47_0
-  cd boost_1_47_0
+  mkdir boost_1_66_0
+  cd boost_1_66_0
   mkdir -p stage/lib
-  unzip ../boost-win32-1.47.0-gitian.zip
+  unzip ../boost-win32-1.66.0-gitian.zip
   cd bin/$GBUILD_BITS
   for lib in *; do
     i586-mingw32msvc-ar rc ../../stage/lib/libboost_${lib}-mt-s.a $lib/*.o
@@ -51,7 +51,7 @@ script: |
   export LD_PRELOAD=/usr/lib/faketime/libfaketime.so.1
   export FAKETIME=$REFERENCE_DATETIME
   export TZ=UTC
-  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_47_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_47_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=okcash QMAKE_LFLAGS=-frandom-seed=okcash USE_BUILD_INFO=1
+  $HOME/qt/src/bin/qmake -spec unsupported/win32-g++-cross MINIUPNPC_LIB_PATH=$HOME/build/miniupnpc MINIUPNPC_INCLUDE_PATH=$HOME/build/ BDB_LIB_PATH=$HOME/build/db-4.8.30.NC/build_unix BDB_INCLUDE_PATH=$HOME/build/db-4.8.30.NC/build_unix BOOST_LIB_PATH=$HOME/build/boost_1_66_0/stage/lib BOOST_INCLUDE_PATH=$HOME/build/boost_1_66_0 BOOST_LIB_SUFFIX=-mt-s BOOST_THREAD_LIB_SUFFIX=_win32-mt-s OPENSSL_LIB_PATH=$HOME/build/openssl-1.0.1b OPENSSL_INCLUDE_PATH=$HOME/build/openssl-1.0.1b/include QRENCODE_LIB_PATH=$HOME/build/qrencode-3.2.0/.libs QRENCODE_INCLUDE_PATH=$HOME/build/qrencode-3.2.0 USE_QRCODE=1 INCLUDEPATH=$HOME/build DEFINES=BOOST_THREAD_USE_LIB BITCOIN_NEED_QT_PLUGINS=1 QMAKE_LRELEASE=lrelease QMAKE_CXXFLAGS=-frandom-seed=okcash QMAKE_LFLAGS=-frandom-seed=okcash USE_BUILD_INFO=1
   make $MAKEOPTS
   cp release/okcash.exe $OUTDIR/
   #

--- a/doc/build-msw.txt
+++ b/doc/build-msw.txt
@@ -26,7 +26,7 @@ Libraries you need to download separately and build:
                 default path               download
 OpenSSL         \openssl-1.0.1b-mgw        http://www.openssl.org/source/
 Berkeley DB     \db-4.8.30.NC-mgw          http://www.oracle.com/technology/software/products/berkeley-db/index.html
-Boost           \boost-1.47.0-mgw          http://www.boost.org/users/download/
+Boost           \boost-1.66.0-mgw          http://www.boost.org/users/download/
 miniupnpc       \miniupnpc-1.6-mgw         http://miniupnp.tuxfamily.org/files/
 
 Their licenses:
@@ -38,7 +38,7 @@ miniupnpc      New (3-clause) BSD license
 Versions used in this release:
 OpenSSL      1.0.1b
 Berkeley DB  4.8.30.NC
-Boost        1.47.0
+Boost        1.66.0
 miniupnpc    1.6
 
 
@@ -63,7 +63,7 @@ Boost
 -----
 DOS prompt:
 downloaded boost jam 3.1.18
-cd \boost-1.47.0-mgw
+cd \boost-1.66.0-mgw
 bjam toolset=gcc --build-type=complete stage
 
 MiniUPnPc

--- a/doc/release-process.txt
+++ b/doc/release-process.txt
@@ -29,11 +29,11 @@
    wget 'http://zlib.net/zlib-1.2.6.tar.gz'
    wget 'ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.9.tar.gz'
    wget 'http://fukuchi.org/works/qrencode/qrencode-3.2.0.tar.bz2'
-   wget 'http://downloads.sourceforge.net/project/boost/boost/1.47.0/boost_1_47_0.tar.bz2'
+   wget 'http://downloads.sourceforge.net/project/boost/boost/1.66.0/boost_1_66_0.tar.bz2'
    wget 'http://download.qt.nokia.com/qt/source/qt-everywhere-opensource-src-4.7.4.tar.gz'
    cd ..
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/boost-win32.yml
-   cp build/out/boost-win32-1.47.0-gitian.zip inputs/
+   cp build/out/boost-win32-1.66.0-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/qt-win32.yml
    cp build/out/qt-win32-4.7.4-gitian.zip inputs/
    ./bin/gbuild ../bitcoin/contrib/gitian-descriptors/deps-win32.yml

--- a/src/json/json_spirit_writer_template.h
+++ b/src/json/json_spirit_writer_template.h
@@ -28,8 +28,6 @@ namespace json_spirit
     template< class String_type >
     String_type non_printable_to_string( unsigned int c )
     {
-        typedef typename String_type::value_type Char_type;
-
         String_type result( 6, '\\' );
 
         result[1] = 'u';

--- a/src/json/json_spirit_writer_template.h
+++ b/src/json/json_spirit_writer_template.h
@@ -28,6 +28,8 @@ namespace json_spirit
     template< class String_type >
     String_type non_printable_to_string( unsigned int c )
     {
+        typedef typename String_type::value_type Char_type;
+
         String_type result( 6, '\\' );
 
         result[1] = 'u';

--- a/src/leveldb/port/atomic_pointer.h
+++ b/src/leveldb/port/atomic_pointer.h
@@ -21,11 +21,12 @@
 #include <stdint.h>
 #ifdef LEVELDB_ATOMIC_PRESENT
 #include <atomic>
-#elif defined(__APPLE__)
-#include <libkern/OSAtomic.h>
 #endif
 #ifdef OS_WIN
 #include <windows.h>
+#endif
+#ifdef OS_MACOSX
+#include <libkern/OSAtomic.h>
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__)

--- a/src/leveldb/port/atomic_pointer.h
+++ b/src/leveldb/port/atomic_pointer.h
@@ -21,12 +21,11 @@
 #include <stdint.h>
 #ifdef LEVELDB_ATOMIC_PRESENT
 #include <atomic>
+#elif defined(__APPLE__)
+#include <libkern/OSAtomic.h>
 #endif
 #ifdef OS_WIN
 #include <windows.h>
-#endif
-#ifdef OS_MACOSX
-#include <libkern/OSAtomic.h>
 #endif
 
 #if defined(_M_X64) || defined(__x86_64__)

--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -69,42 +69,44 @@ OBJS= \
     obj/addrman.o \
     obj/crypter.o \
     obj/key.o \
+    obj/eckey.o \
     obj/db.o \
     obj/init.o \
+    obj/okcashd.o \
     obj/irc.o \
     obj/keystore.o \
-    obj/main.o \
     obj/miner.o \
+    obj/main.o \
     obj/net.o \
     obj/protocol.o \
-    obj/bitcoinrpc.o \
+    obj/rpcprotocol.o \
+    obj/rpcserver.o \
+    obj/rpcclient.o \
     obj/rpcdump.o \
     obj/rpcnet.o \
     obj/rpcmining.o \
     obj/rpcwallet.o \
     obj/rpcblockchain.o \
     obj/rpcrawtransaction.o \
+    obj/rpcsmessage.o \
     obj/script.o \
     obj/sync.o \
     obj/util.o \
+    obj/hash.o \
     obj/wallet.o \
     obj/walletdb.o \
     obj/noui.o \
-    obj/pbkdf2.o \
     obj/kernel.o \
+    obj/pbkdf2.o \
     obj/scrypt.o \
-    obj/scrypt-x86.o \
-    obj/scrypt-x86_64.o \
-    obj/zerocoin/Accumulator.o \
-    obj/zerocoin/AccumulatorProofOfKnowledge.o \
-    obj/zerocoin/Coin.o \
-    obj/zerocoin/CoinSpend.o \
-    obj/zerocoin/Commitment.o \
-    obj/zerocoin/ParamGeneration.o \
-    obj/zerocoin/Params.o \
-    obj/zerocoin/SerialNumberSignatureOfKnowledge.o \
-    obj/zerocoin/SpendMetaData.o \
-    obj/zerocoin/ZeroTest.o
+    obj/smessage.o \
+    obj/stealth.o \
+    obj/ringsig.o \
+    obj/core.o \
+    obj/txmempool.o \
+    obj/chainparams.o \
+    obj/state.o \
+    obj/bloom.o 
 
 ifndef USE_UPNP
 	override USE_UPNP = -

--- a/src/rpcclient.cpp
+++ b/src/rpcclient.cpp
@@ -40,7 +40,7 @@ Object CallRPC(const std::string& strMethod, const Array& params)
     // Connect to localhost
     bool fUseSSL = GetBoolArg("-rpcssl", false);
     ba::io_service io_service;
-    ba::ssl::context context(io_service, ba::ssl::context::sslv23);
+    ba::ssl::context context(ba::ssl::context::sslv23);
     context.set_options(ba::ssl::context::no_sslv2);
     ba::ssl::stream<ba::ip::tcp::socket> sslStream(io_service, context);
     SSLIOStreamDevice<ba::ip::tcp> d(sslStream, fUseSSL);

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -480,8 +480,8 @@ private:
 void ServiceConnection(AcceptedConnection *conn);
 
 // Forward declaration required for RPCListen
-template <typename Protocol, typename SocketAcceptorService>
-static void RPCAcceptHandler(boost::shared_ptr<ba::basic_socket_acceptor<Protocol, SocketAcceptorService> > acceptor,
+template <typename Protocol>
+static void RPCAcceptHandler(boost::shared_ptr<ba::basic_socket_acceptor<Protocol> > acceptor,
                              ba::ssl::context& context,
                              bool fUseSSL,
                              AcceptedConnection* conn,
@@ -490,8 +490,8 @@ static void RPCAcceptHandler(boost::shared_ptr<ba::basic_socket_acceptor<Protoco
 /**
  * Sets up I/O resources to accept and handle a new connection.
  */
-template <typename Protocol, typename SocketAcceptorService>
-static void RPCListen(boost::shared_ptr<ba::basic_socket_acceptor<Protocol, SocketAcceptorService> > acceptor,
+template <typename Protocol>
+static void RPCListen(boost::shared_ptr<ba::basic_socket_acceptor<Protocol> > acceptor,
                    ba::ssl::context& context,
                    const bool fUseSSL)
 {
@@ -501,7 +501,7 @@ static void RPCListen(boost::shared_ptr<ba::basic_socket_acceptor<Protocol, Sock
     acceptor->async_accept(
             conn->sslStream.lowest_layer(),
             conn->peer,
-            boost::bind(&RPCAcceptHandler<Protocol, SocketAcceptorService>,
+            boost::bind(&RPCAcceptHandler<Protocol>,
                 acceptor,
                 boost::ref(context),
                 fUseSSL,
@@ -513,8 +513,8 @@ static void RPCListen(boost::shared_ptr<ba::basic_socket_acceptor<Protocol, Sock
 /**
  * Accept and handle incoming connection.
  */
-template <typename Protocol, typename SocketAcceptorService>
-static void RPCAcceptHandler(boost::shared_ptr<ba::basic_socket_acceptor<Protocol, SocketAcceptorService> > acceptor,
+template <typename Protocol>
+static void RPCAcceptHandler(boost::shared_ptr<ba::basic_socket_acceptor<Protocol> > acceptor,
                              ba::ssl::context& context,
                              const bool fUseSSL,
                              AcceptedConnection* conn,
@@ -583,7 +583,7 @@ void StartRPCThreads()
 
     assert(rpc_io_service == NULL);
     rpc_io_service = new ba::io_service();
-    rpc_ssl_context = new ba::ssl::context(*rpc_io_service, ba::ssl::context::sslv23);
+    rpc_ssl_context = new ba::ssl::context(ba::ssl::context::sslv23);
 
     const bool fUseSSL = GetBoolArg("-rpcssl", false);
 
@@ -602,7 +602,7 @@ void StartRPCThreads()
         else LogPrintf("ThreadRPCServer ERROR: missing server private key file %s\n", pathPKFile.string());
 
         std::string strCiphers = GetArg("-rpcsslciphers", "TLSv1.2+HIGH:TLSv1+HIGH:!SSLv2:!aNULL:!eNULL:!3DES:@STRENGTH");
-        SSL_CTX_set_cipher_list(rpc_ssl_context->impl(), strCiphers.c_str());
+        SSL_CTX_set_cipher_list(rpc_ssl_context->native_handle(), strCiphers.c_str());
     }
 
     // Try a dual IPv6/IPv4 socket, falling back to separate IPv4 and IPv6 sockets
@@ -624,7 +624,6 @@ void StartRPCThreads()
 
         acceptor->bind(endpoint);
         acceptor->listen(ba::socket_base::max_connections);
-
         RPCListen(acceptor, *rpc_ssl_context, fUseSSL);
 
         fListening = true;


### PR DESCRIPTION
Couldn't compile OKCash on my Mac (Mojave) with the Boost 1.66, so I made a few changes after doing some research.
Also I think the OSX makefile was outdated, references some files that didn't exist, so I tweaked this using the unix makefile as a guide.
Seems to be OK (compiles etc) but would certainly be good to get a pair of eyes that are familiar with the codebase on it :-).