### PR TITLE
Add walletlocket param to getwalletinfo

### DIFF
--- a/src/rpcwallet.cpp
+++ b/src/rpcwallet.cpp
@@ -2956,6 +2956,7 @@ Value getwalletinfo(const Array& params, bool fHelp)
     obj.push_back(Pair("txcount",       (int)pwalletMain->mapWallet.size()));
     obj.push_back(Pair("keypoololdest", (boost::int64_t)pwalletMain->GetOldestKeyPoolTime()));
     obj.push_back(Pair("keypoolsize",   (int)pwalletMain->GetKeyPoolSize()));
+    obj.push_back(Pair("walletlocked",      pwalletMain->IsCrypted() ? pwalletMain->IsLocked() ? "Locked" : "Unlocked" : "Uncrypted"));
     if (pwalletMain->IsCrypted())
         obj.push_back(Pair("unlocked_until", (boost::int64_t)nWalletUnlockTime / 1000));
     return obj;


### PR DESCRIPTION
from RPC I cannot get when the wallet is locked or not, because the param `unlocked_until` could also be `0` when the wallet is in staking only and although I can get with `getstakinginfo` if the node is staking or not as I tried [here](https://github.com/dancespiele/okspiel/blob/master/src/utils.rs#L27) there is another issue which it continues showing that staking is true although the wallet is locked even if unlock in no staking mode, only refresh the status when the node is restarted because of this the easy and faster solution and according with my poor knowledge in Cpp I included the `walletlocket` param to `getwalletinfo`